### PR TITLE
Settings: Add an option to change the device hostname (2/2)

### DIFF
--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -169,5 +169,8 @@
     <string name="unknown_night_light_time">Unknown - press to update</string>
     <string name="night_display_location_text">\n\nThe schedule from sunset to sunrise requires enabled location services to get the correct times for your location.</string>
 
+    <!-- Hostname setting -->
+    <string name="device_hostname">Device hostname</string>
+
 </resources>
 

--- a/res/xml/development_settings.xml
+++ b/res/xml/development_settings.xml
@@ -145,6 +145,17 @@
         <Preference android:key="clear_adb_keys"
                     android:title="@string/clear_adb_keys" />
 
+        <com.android.settings.HostnamePreference
+            android:key="device_hostname"
+            android:title="@string/device_hostname"
+            android:dialogTitle="@string/device_hostname"
+            android:positiveButtonText="@string/wifi_save"
+            android:negativeButtonText="@string/wifi_cancel"
+            android:selectAllOnFocus="true"
+            android:imeOptions="actionDone"
+            android:inputType="textNoSuggestions"
+            android:persistent="false" />
+
         <SwitchPreference
             android:key="enable_terminal"
             android:title="@string/enable_terminal_title"

--- a/src/com/android/settings/HostnamePreference.java
+++ b/src/com/android/settings/HostnamePreference.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2013 The CyanogenMod project
+ * Copyright (C) 2018 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings;
+
+import android.content.Context;
+import android.os.SystemProperties;
+import android.provider.Settings;
+import androidx.preference.EditTextPreference;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.util.Log;
+
+public class HostnamePreference extends EditTextPreference {
+
+    private static final String TAG = "HostnamePreference";
+
+    private static final String PROP_HOSTNAME = "net.hostname";
+
+    public HostnamePreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setSummary(getText());
+    }
+
+    @Override
+    public void setText(String text) {
+        if (text == null) {
+            Log.e(TAG, "tried to set null hostname, request ignored");
+            return;
+        }
+        // Remove any character that is not alphanumeric, period, or hyphen
+        text = text.replaceAll("[^-.a-zA-Z0-9]", "");
+        if (TextUtils.isEmpty(text)) {
+            Log.w(TAG, "setting empty hostname");
+        } else {
+            Log.i(TAG, "hostname has been set: " + text);
+        }
+        SystemProperties.set(PROP_HOSTNAME, text);
+        persistHostname(text);
+        setSummary(text);
+    }
+
+    @Override
+    public String getText() {
+        return SystemProperties.get(PROP_HOSTNAME);
+    }
+
+    @Override
+    public void onSetInitialValue(boolean restoreValue, Object defaultValue) {
+        persistHostname(getText());
+    }
+
+    public void persistHostname(String hostname) {
+        Settings.Secure.putString(getContext().getContentResolver(),
+                Settings.Secure.DEVICE_HOSTNAME, hostname);
+    }
+
+}


### PR DESCRIPTION
This adds an option to modify the device hostname used
in ip resolution. This is useful when connecting to the
android device in a dynamic dhcp environment.

Change-Id: I1d8302f06144dbb3e6ddba68594cc5718b4f0bb7
(based on commit Ibc145b74036617248d4f33c6866cc9c8a8cc8974)

Signed-off-by: Joey Huab <joey@evolution-x.org>